### PR TITLE
Handle 72game

### DIFF
--- a/src/poker_now_log_converter/game.py
+++ b/src/poker_now_log_converter/game.py
@@ -62,7 +62,6 @@ class Game:
         # The current largest bet in this street of the hand being parsed
         current_hand_street_max_bet: float = 0
 
-
         # Helper dictionary to keep track of what a given player did last in this hand while parsing.
         # The key is the player_name_with_id attribute.
         prev_action_dict: DefaultDict[str, float] = defaultdict(float)
@@ -144,9 +143,12 @@ class Game:
                     small_blind_seat_number = (utg_seat_number - 1) % num_seats
                     big_blind_seat_number = utg_seat_number
 
-                    button_seat = next((seat for seat in current_hand.seats if seat.seat_number == button_seat_number), None)
-                    small_blind_seat = next((seat for seat in current_hand.seats if seat.seat_number == small_blind_seat_number), None)
-                    big_blind_seat = next((seat for seat in current_hand.seats if seat.seat_number == big_blind_seat_number), None)
+                    button_seat = next(
+                        (seat for seat in current_hand.seats if seat.seat_number == button_seat_number), None)
+                    small_blind_seat = next(
+                        (seat for seat in current_hand.seats if seat.seat_number == small_blind_seat_number), None)
+                    big_blind_seat = next(
+                        (seat for seat in current_hand.seats if seat.seat_number == big_blind_seat_number), None)
 
                     if button_seat:
                         current_hand.dealer = button_seat.seat_player
@@ -476,9 +478,9 @@ class Game:
                         # winning_hand = line.split("with ")[1].split(" (")[0]
 
                         p_seat.seat_summary = f"showed {p_seat.seat_hole_cards} and won " \
-                                              f"({self.currency_symbol}" \
-                                              f"{p_seat.collected_amount:,.2f}) " \
-                                              f"with {winning_hand}"
+                            f"({self.currency_symbol}" \
+                            f"{p_seat.collected_amount:,.2f}) " \
+                            f"with {winning_hand}"
                 else:
                     p_seat.seat_summary = f"collected ({self.currency_symbol}{p_seat.collected_amount:,.2f})"
 

--- a/src/poker_now_log_converter/game.py
+++ b/src/poker_now_log_converter/game.py
@@ -190,7 +190,7 @@ class Game:
                 player_name_with_id = line.split("\" ")[0].split("\"")[1]
                 p_obj = current_hand.get_player_by_player_name_with_id(player_name_with_id)
                 if "raises to " in line:
-                    raise_amount = float(line.split("raises to ")[1])
+                    raise_amount = float(line.split("\" raises to ")[1])
                 else:
                     raise_amount = float(line.split("raises ")[1])
 
@@ -519,7 +519,8 @@ class Game:
                         "chooses to  run it twice." in line or "Dead Small Blind" == line or "The admin updated the "
                                                                                              "player " in line or
                         "the admin queued the stack change " in line or "Undealt cards: " in line or "not run it "
-                                                                                                     "twice." in line):
+                                                                                                     "twice." in line or
+                        "forced the player to away mode" in line or "rejected the seat request" in line):
                     logging.warning("State not considered: %s", line)
 
             if current_hand:

--- a/src/poker_now_log_converter/game.py
+++ b/src/poker_now_log_converter/game.py
@@ -189,7 +189,11 @@ class Game:
                 line = line.replace("with ", "to ")
                 player_name_with_id = line.split("\" ")[0].split("\"")[1]
                 p_obj = current_hand.get_player_by_player_name_with_id(player_name_with_id)
-                raise_amount = float(line.split("to ")[1])
+                if "raises to " in line:
+                    raise_amount = float(line.split("raises to ")[1])
+                else:
+                    raise_amount = float(line.split("raises ")[1])
+
                 difference = raise_amount - current_hand_street_max_bet
                 current_hand_street_max_bet = raise_amount
                 prev_action_dict[player_name_with_id] = raise_amount

--- a/src/poker_now_log_converter/game.py
+++ b/src/poker_now_log_converter/game.py
@@ -163,11 +163,6 @@ class Game:
                     button_seat = next((seat for seat in current_hand.seats if seat.seat_number == 1), None)
                     if button_seat:
                         current_hand.dealer = button_seat.seat_player
-                # current_hand.dealer = button_seat.seat_player
-                # current_hand.small_blind_seat = small_blind_seat
-                # current_hand.small_blind_player = small_blind_seat.seat_player
-                # current_hand.big_blind_seats = [big_blind_seat]
-                # current_hand.big_blind_players = [big_blind_seat.seat_player]
 
             elif "\" raises" in line:
                 line = line.replace(" and go all in", "")

--- a/src/poker_now_log_converter/game.py
+++ b/src/poker_now_log_converter/game.py
@@ -169,7 +169,7 @@ class Game:
                 # current_hand.big_blind_seats = [big_blind_seat]
                 # current_hand.big_blind_players = [big_blind_seat.seat_player]
 
-            elif "raises" in line:
+            elif "\" raises" in line:
                 line = line.replace(" and go all in", "")
                 line = line.replace(" and all in", "")
                 line = line.replace("with ", "to ")
@@ -187,7 +187,7 @@ class Game:
                 if p_seat:
                     p_seat.seat_did_bet = True
 
-            elif "bets" in line:
+            elif "\" bets" in line:
                 line = line.replace(" and go all in", "")
                 line = line.replace(" and all in", "")
                 line = line.replace(" with", "")
@@ -203,7 +203,7 @@ class Game:
                 if p_seat:
                     p_seat.seat_did_bet = True
 
-            elif "calls" in line:
+            elif "\" calls" in line:
                 line = line.replace(" and go all in", "")
                 line = line.replace(" and all in", "")
                 line = line.replace(" with", "")
@@ -225,7 +225,7 @@ class Game:
                 p_seat = current_hand.get_seat_by_player_name_with_id(player_name_with_id)
                 if p_seat:
                     p_seat.seat_did_bet = True
-            elif "checks" in line:
+            elif "\" checks" in line:
                 # print(line)
                 player_name_with_id = line.split("\" ")[0].split("\"")[1]
                 p_obj = current_hand.get_player_by_player_name_with_id(player_name_with_id)
@@ -250,7 +250,7 @@ class Game:
                 if p_seat:
                     p_seat.seat_did_bet = True
 
-            elif "folds" in line:
+            elif "\" folds" in line:
                 player_name_with_id = line.split("\" ")[0].split("\"")[1]
                 p_seat = current_hand.get_seat_by_player_name_with_id(player_name_with_id)
                 p_obj = current_hand.get_player_by_player_name_with_id(player_name_with_id)

--- a/src/poker_now_log_converter/game.py
+++ b/src/poker_now_log_converter/game.py
@@ -134,23 +134,33 @@ class Game:
 
                 # Update button and blind positions
                 num_seats = len(current_hand.seats)
-                button_seat_number = (utg_seat_number - 3) % num_seats
-                small_blind_seat_number = (utg_seat_number - 1) % num_seats
-                big_blind_seat_number = (utg_seat_number - 2) % num_seats
+                available_seats = [seat for seat in current_hand.seats if seat.stack_size > 0]
 
-                button_seat = next((seat for seat in current_hand.seats if seat.seat_number == button_seat_number), None)
-                small_blind_seat = next((seat for seat in current_hand.seats if seat.seat_number == small_blind_seat_number), None)
-                big_blind_seat = next((seat for seat in current_hand.seats if seat.seat_number == big_blind_seat_number), None)
+                if available_seats:
+                    utg_seat = available_seats[0]
+                    utg_seat_number = utg_seat.seat_number
 
-                if button_seat:
-                    current_hand.dealer = button_seat.seat_player
-                if small_blind_seat:
-                    current_hand.small_blind_seat = small_blind_seat
-                    current_hand.small_blind_player = small_blind_seat.seat_player
-                if big_blind_seat:
-                    current_hand.big_blind_seats = [big_blind_seat]
-                    current_hand.big_blind_players = [big_blind_seat.seat_player]
+                    button_seat_number = (utg_seat_number - 2) % num_seats
+                    small_blind_seat_number = (utg_seat_number - 1) % num_seats
+                    big_blind_seat_number = utg_seat_number
 
+                    button_seat = next((seat for seat in current_hand.seats if seat.seat_number == button_seat_number), None)
+                    small_blind_seat = next((seat for seat in current_hand.seats if seat.seat_number == small_blind_seat_number), None)
+                    big_blind_seat = next((seat for seat in current_hand.seats if seat.seat_number == big_blind_seat_number), None)
+
+                    if button_seat:
+                        current_hand.dealer = button_seat.seat_player
+                    if small_blind_seat:
+                        current_hand.small_blind_seat = small_blind_seat
+                        current_hand.small_blind_player = small_blind_seat.seat_player
+                    if big_blind_seat:
+                        current_hand.big_blind_seats = [big_blind_seat]
+                        current_hand.big_blind_players = [big_blind_seat.seat_player]
+                else:
+                    # If no available seats, assume button is at seat 1
+                    button_seat = next((seat for seat in current_hand.seats if seat.seat_number == 1), None)
+                    if button_seat:
+                        current_hand.dealer = button_seat.seat_player
                 # current_hand.dealer = button_seat.seat_player
                 # current_hand.small_blind_seat = small_blind_seat
                 # current_hand.small_blind_player = small_blind_seat.seat_player

--- a/src/poker_now_log_converter/hand.py
+++ b/src/poker_now_log_converter/hand.py
@@ -250,12 +250,12 @@ class Hand:
         date_formatted = self.hand_start_datetime.strftime(f"%Y/%m/%d %H:%M:%S {timezone}")
 
         if not self.dealer:
-            # Dead button, so select the seat three places before the first available seat to be the button
+            # Dead button, so select the seat two places before the big blind to be the button
             # This may be an empty seat
+            # The small blind may also be empty
             # Seat numbers are 1-indexed
             available_seats = [seat for seat in self.seats if seat.stack_size > 0]
             if available_seats:
-                # first_available_seat_number = available_seats[0].seat_number
                 button_seat_id = ((self.big_blind_seats[0].seat_number - 3) % 10) + 1
             else:
                 # If no available seats, assume button is seat 1

--- a/src/poker_now_log_converter/hand.py
+++ b/src/poker_now_log_converter/hand.py
@@ -250,11 +250,16 @@ class Hand:
         date_formatted = self.hand_start_datetime.strftime(f"%Y/%m/%d %H:%M:%S {timezone}")
 
         if not self.dealer:
-            # Dead button, so select the seat two places before the big blind to be the button
+            # Dead button, so select the seat three places before the first available seat to be the button
             # This may be an empty seat
-            # The small blind may also be empty
             # Seat numbers are 1-indexed
-            button_seat_id = ((self.big_blind_seats[0].seat_number - 3) % 10) + 1
+            available_seats = [seat for seat in self.seats if seat.stack_size > 0]
+            if available_seats:
+                first_available_seat_number = available_seats[0].seat_number
+                button_seat_id = ((first_available_seat_number - 4) % 10) + 1
+            else:
+                # If no available seats, assume button is seat 1
+                button_seat_id = 1
         else:
             button_seat = self.get_seat_by_player_name_with_id(self.dealer.player_name_with_id)
             button_seat_id = button_seat.seat_number

--- a/src/poker_now_log_converter/hand.py
+++ b/src/poker_now_log_converter/hand.py
@@ -402,8 +402,8 @@ class Hand:
 
             # Now construct the seat summary line
             summary_line = f"Seat {seat.seat_number}: " \
-                           f"{seat.seat_player.alias_name or seat.seat_player.player_name}{seat.seat_desc} " \
-                           f"{seat.seat_summary}{seat.seat_run_it_twice_summary}"
+                f"{seat.seat_player.alias_name or seat.seat_player.player_name}{seat.seat_desc} " \
+                f"{seat.seat_summary}{seat.seat_run_it_twice_summary}"
             # If we know the hole cards (and they weren't mentioned earlier in the summary, put them at the end)
             if "showed" not in seat.seat_summary and seat.seat_hole_cards:
                 summary_line += " " + seat.seat_hole_cards

--- a/src/poker_now_log_converter/hand.py
+++ b/src/poker_now_log_converter/hand.py
@@ -256,7 +256,7 @@ class Hand:
             available_seats = [seat for seat in self.seats if seat.stack_size > 0]
             if available_seats:
                 first_available_seat_number = available_seats[0].seat_number
-                button_seat_id = ((first_available_seat_number - 4) % 10) + 1
+                button_seat_id = ((self.big_blind_seats[0].seat_number - 3) % 10) + 1
             else:
                 # If no available seats, assume button is seat 1
                 button_seat_id = 1

--- a/src/poker_now_log_converter/hand.py
+++ b/src/poker_now_log_converter/hand.py
@@ -255,7 +255,7 @@ class Hand:
             # Seat numbers are 1-indexed
             available_seats = [seat for seat in self.seats if seat.stack_size > 0]
             if available_seats:
-                first_available_seat_number = available_seats[0].seat_number
+                # first_available_seat_number = available_seats[0].seat_number
                 button_seat_id = ((self.big_blind_seats[0].seat_number - 3) % 10) + 1
             else:
                 # If no available seats, assume button is seat 1

--- a/src/poker_now_log_converter/main.py
+++ b/src/poker_now_log_converter/main.py
@@ -65,7 +65,7 @@ def save_game_to_file_pokerstars(game: Game, output_dir: str, new_filename: str 
 
         if not new_filename:
             new_filename = f"ConvertedPNLog-{first_hand_date_formatted}-" \
-                           f"{first_hand_ss}-{first_hand_bb}-{first_hand_type}.txt"
+                f"{first_hand_ss}-{first_hand_bb}-{first_hand_type}.txt"
 
         # Create output directory create it if it doesn't exist already
         output_path = Path(output_dir).resolve()

--- a/src/poker_now_log_converter/utils.py
+++ b/src/poker_now_log_converter/utils.py
@@ -159,10 +159,10 @@ def is_two_pair(hand: Tuple[Card]) -> Optional[Tuple[str, PokerHand, int]]:
 
                 # Take the hash of the remaining cards, add to the hashes of each of the two pair
                 hash_value = hash_cards(remaining_card) + (hand_rank_values[two_pair[1]] * pow(BASE_K, 1)) + (
-                        hand_rank_values[two_pair[0]] * pow(BASE_K, 2))
+                    hand_rank_values[two_pair[0]] * pow(BASE_K, 2))
 
                 return f"two pair, {hand_rank_names_plural[two_pair[0]]} and {hand_rank_names_plural[two_pair[1]]}", \
-                       PokerHand.TWO_PAIR, hash_value
+                    PokerHand.TWO_PAIR, hash_value
 
     return None
 
@@ -205,7 +205,7 @@ def is_straight(hand: Tuple[Card]) -> Optional[Tuple[str, PokerHand, int]]:
             hash_value = hand_rank_values[top_of_streak]
 
             return f"a straight, {hand_rank_names_singular[rank]} to {hand_rank_names_singular[top_of_streak]}", \
-                   PokerHand.STRAIGHT, hash_value
+                PokerHand.STRAIGHT, hash_value
 
         # Account for low ace
         if i == len(list(rank_histogram.keys())) - 1 and streak == 3 and rank == "2" and any(
@@ -215,7 +215,7 @@ def is_straight(hand: Tuple[Card]) -> Optional[Tuple[str, PokerHand, int]]:
             # For the hash value, we can just use the top of the streak
             hash_value = hand_rank_values[top_of_streak]
             return f"a straight, {hand_rank_names_singular['A']} to {hand_rank_names_singular[top_of_streak]}", \
-                   PokerHand.STRAIGHT, hash_value
+                PokerHand.STRAIGHT, hash_value
 
     return None
 
@@ -261,7 +261,7 @@ def is_full_house(hand: Tuple[Card]) -> Optional[Tuple[str, PokerHand, int]]:
             highest_three_of_a_kind] * pow(BASE_K, 1)
 
         return f"a full house, {hand_rank_names_plural[highest_three_of_a_kind]} full of " \
-               f"{hand_rank_names_plural[highest_pair]}", PokerHand.FULL_HOUSE, hash_value
+            f"{hand_rank_names_plural[highest_pair]}", PokerHand.FULL_HOUSE, hash_value
 
     return None
 
@@ -312,7 +312,7 @@ def is_straight_flush(hand: Tuple[Card]) -> Optional[Tuple[str, PokerHand, int]]
                 hash_value = hand_rank_values[top_of_streak.rank]
 
                 return f"a straight flush, {hand_rank_names_singular[c.rank]} to" \
-                       f" {hand_rank_names_singular[top_of_streak.rank]}", PokerHand.STRAIGHT_FLUSH, hash_value
+                    f" {hand_rank_names_singular[top_of_streak.rank]}", PokerHand.STRAIGHT_FLUSH, hash_value
 
             # Account for low ace
             if i == len(flush_cards) - 1 and streak == 3 and c.rank == "2" and any([c for c in hand if c.rank == "A"]):
@@ -321,7 +321,7 @@ def is_straight_flush(hand: Tuple[Card]) -> Optional[Tuple[str, PokerHand, int]]
                 # For the hash value, we can just use the top of the streak
                 hash_value = hand_rank_values[top_of_streak]
                 return f"a straight flush, {hand_rank_names_singular['A']} to" \
-                       f" {hand_rank_names_singular[top_of_streak]}", PokerHand.STRAIGHT_FLUSH, hash_value
+                    f" {hand_rank_names_singular[top_of_streak]}", PokerHand.STRAIGHT_FLUSH, hash_value
 
     return None
 


### PR DESCRIPTION
# Add 7-2 Bounty Hand Skipping and Reporting

## Summary
This PR modifies the `Game` class to skip 7-2 bounty hands during processing and report the number of skipped hands in the output. This change addresses the issue of 7-2 bounty hands causing problems in the conversion process. This fixes [the following issue](https://github.com/charlestudor/PokerNowLogConverter/issues/16).

## Changes
- Added logic in `Game.__init__` to detect and skip 7-2 bounty hands
- Implemented a counter for skipped 7-2 bounty hands
- Added a brief message, per your recommendation, on the hands / amount of hands skipped.

Please review and let me know if any further changes or clarifications are needed. 

Unrelatedly, I submitted the issue for this a while ago...just sat down to tackle it and that took roughly 2minutes, so jeez -- sorry for the wait.